### PR TITLE
Tweaked parameters to show phase mixing

### DIFF
--- a/1DVlasovSolverIteration1.py
+++ b/1DVlasovSolverIteration1.py
@@ -1,17 +1,23 @@
-import jax
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
 import matplotlib.animation as animation
 import diffrax 
 
 # Variables
-vMin, vMax = -10, 10  # Velocity Range
-xMin, xMax = -10, 10   # Position in x Range
-Nv = 500              # Number of Velocity Points
-Nx = 500              # Number of Position Points
 vT = 1.0              # Thermal Velocity
+vMin, vMax = -4*vT, 4*vT  # Velocity Range
+xMin, xMax = -1, 1   # Position in x Range
+Nv = 150              # Number of Velocity Points
+Nx = 150              # Number of Position Points
 n0 = 2.0              # Number Density
-E0 = -1                # Constant Electric Field
+E0 = 0#-4              # Constant Electric Field
+wavenumber = 4         # Wavenumber
+t0 = 0
+tFinal = 1
+nt = 100
+δt = 0.01
+rtol = 1e-5
+atol = 1e-5
 
 v = jnp.linspace(vMin, vMax, Nv)  # Velocity Array
 x = jnp.linspace(xMin, xMax, Nx)   # Position Array
@@ -20,7 +26,7 @@ delta_v = (vMax - vMin) / (Nv - 1)  # delta_v
 
 # Create meshgrids for x and v and initial condition
 X, V = jnp.meshgrid(x, v, indexing='ij')
-f0 = n0 / jnp.sqrt(2 * jnp.pi * vT**2) * jnp.exp(-(X**2 + V**2) / (2 * vT**2))
+f0 = n0 / jnp.sqrt(2 * jnp.pi * vT**2) * jnp.exp(-(V**2) / (2 * vT**2)) * (1 + 0.1 * jnp.sin(wavenumber * 2 * jnp.pi * X / (xMax - xMin)))
 
 # Central Difference in x
 def central_diff_x(f, dx):
@@ -38,17 +44,10 @@ def vector_field(t, f, args):
 term = diffrax.ODETerm(vector_field)
 
 # Temporal discretization
-t0 = 0
-tFinal = 1
-δt = 0.0001
-saveat = diffrax.SaveAt(ts=jnp.linspace(t0, tFinal, 50))
+saveat = diffrax.SaveAt(ts=jnp.linspace(t0, tFinal, nt))
 
 # Tolerances
-rtol = 1e-10
-atol = 1e-10
-stepsize_controller = diffrax.PIDController(
-    pcoeff=0.3, icoeff=0.4, rtol=rtol, atol=atol, dtmax=0.001
-)
+stepsize_controller = diffrax.PIDController(rtol=rtol, atol=atol)#diffrax.PIDController(pcoeff=0.3, icoeff=0.4, rtol=rtol, atol=atol, dtmax=0.001)
 
 # Solver
 solver = diffrax.Tsit5()
@@ -67,12 +66,12 @@ sol = diffrax.diffeqsolve(
 
 # Animiation
 fig, ax = plt.subplots(figsize=(5, 5))
-im = ax.imshow(sol.ys[0], origin="lower", extent=(xMin, xMax, vMin, vMax), aspect='auto', cmap="inferno")
+im = ax.imshow(sol.ys[0].transpose(), origin="lower", extent=(xMin, xMax, vMin, vMax), aspect='auto', cmap="inferno")
 ax.set_xlabel("x")
 ax.set_ylabel("v", rotation=0)
 
 def animate(i):
-    im.set_data(sol.ys[i])
+    im.set_data(sol.ys[i].transpose())
     ax.set_title(f"t = {sol.ts[i]:.2f}")
     im.set_clim(0, 1)
 


### PR DESCRIPTION
See Section III of https://w3.pppl.gov/~hammett/gyrofluid/papers/1992/Hammett_92_Landau_fluid_corrected.pdf
Animation shows textbook phase-mixing:
- see Fig. 16 of https://www-thphys.physics.ox.ac.uk/people/AlexanderSchekochihin/notes/LESHOUCHES19/KTLectureNotes.pdf
- see slide 3 of https://www-thphys.physics.ox.ac.uk/people/mbarnes/presentations/vienna2010_phasemix.pdf

typical benchmarks of phase-mixing: check that density is decaying to zero as predicted by the formula 3 of https://w3.pppl.gov/~hammett/gyrofluid/papers/1992/Hammett_92_Landau_fluid_corrected.pdf

Main change: initial distribution should be Gaussian in velocity and sinusoidal in space

To make the code faster: perform Fourier transform derivatives instead of finite differences (see this function on how to get the electric field given charge density, i.e., sum of f over velocity: https://github.com/uwplasma/JAX-in-Cell/blob/main/jaxincell/fields.py#L8)